### PR TITLE
terminal/color: fix typo in package docstring.

### DIFF
--- a/color/color.go
+++ b/color/color.go
@@ -1,4 +1,4 @@
-// The colors package provide a simple way to bring colorful charcaters to terminal interface.
+// The colors package provide a simple way to bring colorful characters to terminal interface.
 //
 // This example will output the text with a Blue foreground and a Black background
 //      color.Println("@{bK}Example Text")


### PR DESCRIPTION
There was a small typo in the word "character".